### PR TITLE
implement UnmarshalJSON interface

### DIFF
--- a/jason.go
+++ b/jason.go
@@ -764,3 +764,12 @@ func (v *Object) String() string {
 	return string(f)
 
 }
+
+// UnmarshalJSON implements the encoding/json Marshaller interface.
+//
+// Example:
+//             var v jason.Value
+//             err := json.Unmarshal(`{"foo": "bar"}`, &v)
+func (j *Value) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &j.data)
+}

--- a/jason.go
+++ b/jason.go
@@ -166,7 +166,7 @@ func (v *Object) GetValue(keys ...string) (*Value, error) {
 // Returns error if the value is not a json object.
 // Example:
 //		object, err := GetObject("person", "address")
-func (v *Object) GetObject(keys ...string) (*Object, error) {
+func (v *Value) GetObject(keys ...string) (*Object, error) {
 	child, err := v.getPath(keys)
 
 	if err != nil {
@@ -190,7 +190,7 @@ func (v *Object) GetObject(keys ...string) (*Object, error) {
 // Returns error if the value is not a json string.
 // Example:
 //		string, err := GetString("address", "street")
-func (v *Object) GetString(keys ...string) (string, error) {
+func (v *Value) GetString(keys ...string) (string, error) {
 	child, err := v.getPath(keys)
 
 	if err != nil {
@@ -307,7 +307,7 @@ func (v *Object) GetBoolean(keys ...string) (bool, error) {
 //		for i, friend := range friends {
 //			... // friend will be of type Value here
 //		}
-func (v *Object) GetValueArray(keys ...string) ([]*Value, error) {
+func (v *Value) GetValueArray(keys ...string) ([]*Value, error) {
 	child, err := v.getPath(keys)
 
 	if err != nil {
@@ -328,7 +328,7 @@ func (v *Object) GetValueArray(keys ...string) ([]*Value, error) {
 //		for i, friend := range friends {
 //			... // friend will be of type Object here
 //		}
-func (v *Object) GetObjectArray(keys ...string) ([]*Object, error) {
+func (v *Value) GetObjectArray(keys ...string) ([]*Object, error) {
 	child, err := v.getPath(keys)
 
 	if err != nil {

--- a/jason_test.go
+++ b/jason_test.go
@@ -142,7 +142,7 @@ func TestFirst(t *testing.T) {
 }
 
 func TestSecond(t *testing.T) {
-	json := `
+	testJSON := `
   {
    "data": [
       {
@@ -189,7 +189,8 @@ func TestSecond(t *testing.T) {
   }`
 
 	assert := NewAssert(t)
-	j, err := NewObjectFromBytes([]byte(json))
+
+	j, err := NewObjectFromBytes([]byte(testJSON))
 
 	assert.True(j != nil && err == nil, "failed to parse json")
 

--- a/jason_test.go
+++ b/jason_test.go
@@ -1,6 +1,7 @@
 package jason
 
 import (
+	"encoding/json"
 	"log"
 	"testing"
 )
@@ -228,4 +229,18 @@ func TestSecond(t *testing.T) {
 
 	}
 
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	assert := NewAssert(t)
+	str := `{ "data": [{ "bar": 12 }]}`
+
+	var j *Value = &Value{}
+
+	err := json.Unmarshal([]byte(str), j)
+
+	assert.True(j != nil && err == nil, "failed to parse json")
+
+	dataArray, err := j.GetObjectArray("data")
+	assert.True(dataArray != nil && err == nil, "data should be an object array")
 }


### PR DESCRIPTION
This patch makes it possible to deserialize JSON into `jason.Value`s directly. This is useful if jason.Values are used as part of a larger struct like so:

```go
type X struct {
  key string `json:"key"`
  value jason.Value `json:"value"`
}

var x X

str := `{"key": "foo", "value": { "a": 3, "b": "bar" }}`
json.Unmarshal([]byte(str), &x)
```


For this to be useful I had to move Implementations of the `Get...`set of methods from `Object` over to `Value`, I'm not sure this is correct and a good Idea. I don't really understand why the Value/Object distinction exists.