### PR TITLE
Add more descriptive error messages

### DIFF
--- a/jason.go
+++ b/jason.go
@@ -50,6 +50,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -137,7 +138,7 @@ func (v *Value) get(key string) (*Value, error) {
 		if ok {
 			return child, nil
 		} else {
-			return nil, errors.New("key not found")
+			return nil, fmt.Errorf("key '%s' not found", key)
 		}
 	}
 


### PR DESCRIPTION
Return `key 'some_key' not found` instead of `key not found`.

It's very confusing when you pass an error along a few functions and have no idea which key was not found.
An alternative is using `fmt.Errorf("Error while retrieving key %s: %v", key, err)` but I think this method is more clear.