### PR TITLE
Add Error types

### DIFF
--- a/jason.go
+++ b/jason.go
@@ -64,6 +64,18 @@ var (
 	ErrNotString = errors.New("not a string")
 )
 
+type KeyNotFoundError struct {
+	Key string
+}
+
+func (k KeyNotFoundError) Error() string {
+	if k.Key != "" {
+		return fmt.Sprintf("key '%s' not found", k.Key)
+	}
+
+	return "key not found"
+}
+
 // Value represents an arbitrary JSON value.
 // It may contain a bool, number, string, object, array or null.
 type Value struct {
@@ -148,7 +160,7 @@ func (v *Value) get(key string) (*Value, error) {
 		if ok {
 			return child, nil
 		} else {
-			return nil, fmt.Errorf("key '%s' not found", key)
+			return nil, KeyNotFoundError{key}
 		}
 	}
 

--- a/jason.go
+++ b/jason.go
@@ -54,6 +54,16 @@ import (
 	"io"
 )
 
+// Error values returned when validation functions fail
+var (
+	ErrNotNull   = errors.New("is not null")
+	ErrNotArray  = errors.New("Not an array")
+	ErrNotNumber = errors.New("not a number")
+	ErrNotBool   = errors.New("no bool")
+	ErrNotObject = errors.New("not an object")
+	ErrNotString = errors.New("not a string")
+)
+
 // Value represents an arbitrary JSON value.
 // It may contain a bool, number, string, object, array or null.
 type Value struct {
@@ -586,7 +596,7 @@ func (v *Value) Null() error {
 		return nil
 	}
 
-	return errors.New("is not null")
+	return ErrNotNull
 
 }
 
@@ -617,7 +627,7 @@ func (v *Value) Array() ([]*Value, error) {
 		return slice, nil
 	}
 
-	return slice, errors.New("Not an array")
+	return slice, ErrNotArray
 
 }
 
@@ -639,7 +649,7 @@ func (v *Value) Number() (json.Number, error) {
 		return v.data.(json.Number), nil
 	}
 
-	return "", errors.New("not a number")
+	return "", ErrNotNumber
 }
 
 // Attempts to typecast the current value into a float64.
@@ -688,7 +698,7 @@ func (v *Value) Boolean() (bool, error) {
 		return v.data.(bool), nil
 	}
 
-	return false, errors.New("no bool")
+	return false, ErrNotBool
 }
 
 // Attempts to typecast the current value into an object.
@@ -726,7 +736,7 @@ func (v *Value) Object() (*Object, error) {
 		return obj, nil
 	}
 
-	return nil, errors.New("not an object")
+	return nil, ErrNotObject
 }
 
 // Attempts to typecast the current value into a string.
@@ -747,7 +757,7 @@ func (v *Value) String() (string, error) {
 		return v.data.(string), nil
 	}
 
-	return "", errors.New("not a string")
+	return "", ErrNotString
 }
 
 // Returns the value a json formatted string.

--- a/jason_test.go
+++ b/jason_test.go
@@ -236,3 +236,53 @@ func TestSecond(t *testing.T) {
 	}
 
 }
+
+func TestErrors(t *testing.T) {
+	json := `
+  {
+    "string": "hello",
+    "number": 1,
+    "array": [1,2,3]
+  }`
+
+	errstr := "expected an error getting %s, but got '%s'"
+
+	j, err := NewObjectFromBytes([]byte(json))
+	if err != nil {
+		t.Fatal("failed to parse json")
+	}
+
+	if _, err = j.GetObject("string"); err != ErrNotObject {
+		t.Errorf(errstr, "object", err)
+	}
+
+	if err = j.GetNull("string"); err != ErrNotNull {
+		t.Errorf(errstr, "null", err)
+	}
+
+	if _, err = j.GetStringArray("string"); err != ErrNotArray {
+		t.Errorf(errstr, "array", err)
+	}
+
+	if _, err = j.GetStringArray("array"); err != ErrNotString {
+		t.Errorf(errstr, "string array", err)
+	}
+
+	if _, err = j.GetNumber("array"); err != ErrNotNumber {
+		t.Errorf(errstr, "number", err)
+	}
+
+	if _, err = j.GetBoolean("array"); err != ErrNotBool {
+		t.Errorf(errstr, "boolean", err)
+	}
+
+	if _, err = j.GetString("number"); err != ErrNotString {
+		t.Errorf(errstr, "string", err)
+	}
+
+	_, err = j.GetString("not_found")
+	if e, ok := err.(KeyNotFoundError); !ok {
+		t.Errorf(errstr, "key not found error", e)
+	}
+
+}


### PR DESCRIPTION
All of the `Get*()` functions of the library such as

- `GetValue()`
- `GetObject()`
- `GetString()`
- `GetNumber()`
- etc.

return a pair of `(<value type>, error)`.

Creating the errors this way makes it difficult for clients of this library to determine exactly ​*which*​ error occurred. For example, calling `GetInt64("keyname")` can return an error if either the value is not an `int64` or if the key `keyname` does not exist. The only way for a client to distinguish between these two errors with string comparison on the error message itself.

Checking the error message string can be brittle. Our team recently had a bug in a project which uses this library because we were checking for the error message to be `"key not found", but [this](https://github.com/antonholmquist/jason/commit/307fab7f651505c1c47e898218cec1c21466944f) commit made our string comparison fail.

It's much friendlier to consumers to provide some exported error variables or types they can check against.

Thanks to @bbokorney for pairing with me for the fix.