### PR TITLE
Set exists to true when value could be parsed

### DIFF
--- a/jason.go
+++ b/jason.go
@@ -113,6 +113,7 @@ func NewValueFromReader(reader io.Reader) (*Value, error) {
 	d := json.NewDecoder(reader)
 	d.UseNumber()
 	err := d.Decode(&j.data)
+	j.exists = err == nil
 	return j, err
 }
 


### PR DESCRIPTION
Without this fix, parsing "null" and then calling Null() on the resulting Value will return an error because exists is never assigned to true.